### PR TITLE
2024 layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ define("URLMASK"
 Using **docker-compose**, and after configuration, the whole environment can be run as follows :
 
 1. `docker-compose up` in the root repository directory will initiate a local development environment
-2. Once launched, run `docker exec -it etaamb_steward run db_setup` in another terminal to crete the database tables
+2. Once launched, run `docker exec -it etaamb_steward run db_setup` in another terminal to create the database tables
 3. TODO
 
 ## Logging

--- a/agent/moniteur_import/Page.pm
+++ b/agent/moniteur_import/Page.pm
@@ -671,7 +671,8 @@ sub getPromDate
         return $1."-".$2."-".$3;
         }
 
-    if ($self->{_content} =~ m/<h3><center><u>\s(\d{1,2})\s(\w{1,})\s(\d{4})\./i)
+    #if ($self->{_content} =~ m/<h3><center><u>\s(\d{1,2})\s(\w{1,})\s(\d{4})\./i)
+    if ($self->{_content} =~ m/"intro-text">\s*(\d{1,2})\s(\w{1,})\s(\d{4})\./i)
         {
         if (exists($months{$2}))
             {
@@ -738,7 +739,7 @@ sub getType
         $term  = @{$termdef}[0];
         for my $mask (@{@{$termdef}[1]})
             {
-            if ($title =~ m/^$mask|^(\s*(\d+\/){2}\d+\s*\.?|\s*\d+(er)?\s+\w+\s+\d+\s*\.?|[^\.]*\.\s*|\s*)-?\s*[^a-z]{0,}$mask/i)
+            if ($title =~ m/^$mask|^(\s*(\d+\/){2}\d+\s*\.?|\s*\d+(er)?\s*\w+\s*\d+\s*\.?|[^\.]*\.\s*|\s*)-?\s*[^a-z]{0,}$mask/i)
                 {
                 return $term;
                 }
@@ -801,7 +802,8 @@ sub getSource
 		return "nosource";
         }
 
-    if ($self->{_content} =~ m/^<font>([^<]+)<\/font><\/td><\/tr>/im)
+    #if ($self->{_content} =~ m/^<font>([^<]+)<\/font><\/td><\/tr>/im)
+    if ($self->{_content} =~ m/h1 class="page__title">\s*<span>([^<]+)\s*<\/span>/im)
 		{
         return $1;
 		}
@@ -847,7 +849,8 @@ sub getPdf
 		return undef;
         }
 
-    if ($self->{_content} =~ m/name=urlpdf value="([^"]+)"/i)
+    #if ($self->{_content} =~ m/name=urlpdf value="([^"]+)"/i)
+    if ($self->{_content} =~ m/href="(\/mopdf[^"]+)"/i)
 		{
         return $1 =~ s/^\s+|\s+$//rg;;
 		}
@@ -927,16 +930,17 @@ sub getTitle
 	my $text = $self->{_raw};
 	my $final_title= '';
 
-	if ($text =~ m/<h3><center><u>(([^\.]+\.)?(\s\-)?\s?(?<title>.+?)|\s*)<\/u><\/center><\/h3><br>\s*(?<sub_title>[\s\S]{0,250})[^<]*<br>(?<text_begin>[\s\S]{0,100})/im)
+    # if ($text =~ m/<h3><center><u>(([^\.]+\.)?(\s\-)?\s?(?<title>.+?)|\s*)<\/u><\/center><\/h3><br>\s*(?<sub_title>[\s\S]{0,250})[^<]*<br>(?<text_begin>[\s\S]{0,100})/im)
+	if ($text =~ m/"intro-text">\s*(([^\.]+\.)?(\s\-)?\s?(?<title>.+?)|\s*)\s*<\/p>\s*<p class="intro-date">(?<sub_title>[\s\S]{0,250})<\/p>[\s\S]+role="main">\s*(?<text_begin>[\s\S]{0,100})/im)
 		{
 		my $title 		= $+{title};
 		my $sub_title = $+{sub_title};
 		my $text_begin = $+{text_begin};
-		if ($title !~ m/^\s*$/)	
+		if (defined $title && $title !~ m/^\s*$/)	
 			{
 			$final_title = $title;
 			}
-		elsif ($sub_title !~ m/^\s*$/)
+		elsif (defined $sub_title && $sub_title !~ m/^\s*$/)
 			{
 			my $hs = HTML::Strip->new();
 			$final_title = $hs->parse($sub_title.'(...) '.$text_begin.'(...)');

--- a/agent/moniteur_import/getRaws.pl
+++ b/agent/moniteur_import/getRaws.pl
@@ -2,6 +2,9 @@
 # Author:    Pieterjan  Montens <gnaeus@gnaeus_app.willy.manor>
 # Created:   Fri Aug 6 13:34:38 2010 +0000
 # Description: Raw Page getter
+# Changelog:
+# Sun May 26 22:07:00 2024 +0001
+#   - Adapt to new layout
 #
 # Db form: id | numac | pub_date | raw_fr | raw_nl
 # Get X pages on each run
@@ -63,10 +66,12 @@ for my $doc (@todo)
 
 	print "\tGetting pages for doc $numac, $pub_date..";
 
-	$url_nl = sprintf("http://www.ejustice.just.fgov.be/cgi/article_body.pl?language=%s&caller=summary&pub_date=%s&numac=%u", 'nl', $pub_date, $numac);
-	$url_fr = sprintf("http://www.ejustice.just.fgov.be/cgi/article_body.pl?language=%s&caller=summary&pub_date=%s&numac=%u", 'fr', $pub_date, $numac);
+	$url_nl = sprintf("https://www.ejustice.just.fgov.be/cgi/article.pl?language=%s&sum_date=%s&lg_txt=%s&caller=sum&numac_search=%s&view_numac=", 'nl', $pub_date, 'n', $numac);
 
-	$page_nl = getPage($url_nl);
+	$url_fr = sprintf("https://www.ejustice.just.fgov.be/cgi/article.pl?language=%s&sum_date=%s&lg_txt=%s&caller=sum&numac_search=%s&view_numac=", 'fr', $pub_date, 'f', $numac);
+
+
+    $page_nl = getPage($url_nl);
 	$page_fr = getPage($url_fr);
 
 	if ($page_nl && $page_fr)
@@ -82,7 +87,7 @@ for my $doc (@todo)
 	print " Done\n";
 	}
 
-print "\n";
+print "\nAll done\n";
 
 ## Subs
 sub getPage

--- a/agent/moniteur_import/getRaws.pl
+++ b/agent/moniteur_import/getRaws.pl
@@ -3,14 +3,17 @@
 # Created:   Fri Aug 6 13:34:38 2010 +0000
 # Description: Raw Page getter
 # Changelog:
-# Sun May 26 22:07:00 2024 +0001
-#   - Adapt to new layout
+#   Sun May 26 22:07:00 2024 +0001
+#       - Adapt to new layout
 #
 # Db form: id | numac | pub_date | raw_fr | raw_nl
 # Get X pages on each run
 
 my $version = 1;
 my $page_number = 50;
+# All raw version before 16/05/2024 : original"
+# All raw verions after the 16/05/2025 update: 052024
+my $raw_source_version = "052024";
 
 ## Pause between pages
 $max_pause = 80;
@@ -56,7 +59,7 @@ while (my @data = $sth->fetchrow_array())
 	push @todo,$res;
 	}
 
-my $insert = $dbh->prepare("Insert into raw_pages(numac, pub_date, raw_fr, raw_nl, version) values (?,?,?,?,?)");
+my $insert = $dbh->prepare("Insert into raw_pages(numac, pub_date, raw_fr, raw_nl, version, raw_source_version) values (?,?,?,?,?,?)");
 $sleep = 0;
 
 for my $doc (@todo)
@@ -76,7 +79,7 @@ for my $doc (@todo)
 
 	if ($page_nl && $page_fr)
 		{
-		$insert->execute($numac,$pub_date,$page_fr,$page_nl,$version);
+		$insert->execute($numac,$pub_date,$page_fr,$page_nl,$version,$raw_source_version);
 		}
 	print " Done\n";
 

--- a/agent/moniteur_import/parseRaws.pl
+++ b/agent/moniteur_import/parseRaws.pl
@@ -30,10 +30,14 @@ $|=1;
 
 # #### Version changelog
 # ######################
+# 18 : New MB version after 16/05/2024
 # 17 : Chrono ID, Senate & Chamber ID & Leg
 # < 17 : Original etaamb format (historical)
-my $version=17;
+my $version=18;
 
+# this version of parseraws is made to work with following raw versions :
+# (previous file is compatible with "original" only)
+my $raw_source_version = "052024";
 
 my $loop_num=1;
 if (defined $ENV{THREADS}) {
@@ -66,11 +70,11 @@ do {
 
 	my $sql = "select raw_pages.numac from raw_pages 
 			   left join docs on raw_pages.numac=docs.numac 
-			   where docs.numac is null
+			   where docs.numac is null and raw_source_version = $raw_source_version
 			    union
 			   select raw_pages.numac from raw_pages 
 			   left join docs on raw_pages.numac=docs.numac 
-			   where docs.version != $version
+			   where docs.version != $version and raw_source_version = $raw_source_version
 			   limit 0, 1000";
 
 	my $sth = $dbh->prepare($sql);

--- a/agent/moniteur_import/recupId.pl
+++ b/agent/moniteur_import/recupId.pl
@@ -2,6 +2,9 @@
 # Author:    Pieterjan  Montens <gnaeus@gnaeus_app.willy.manor>
 # Created:   Fri Aug 6 13:34:38 2010 +0000
 # Description: Document ID getter for belgian official journal
+# Changelog:
+#   Sun May 26 22:07:00 2024 +0001
+#       - Adapt to new layout
 #
 # 1) generate date list
 # 2) filter out done dates and get 10 dates 
@@ -12,7 +15,9 @@ use LWP::Simple;
 use LWP::UserAgent;
 use HTTP::Request;
 use HTTP::Response;
+use URI::Escape;
 use DBI;
+use Data::Dumper;
 $| = 1;
 use constant TRUE => 1;
 use constant FALSE => 0;
@@ -25,7 +30,7 @@ $dates_to_parse=400;
 $max_pause = 500;
 $min_pause = 100;
 
-$version = 1;
+$version = 2;
 
 ## Database init
 $db = $ENV{'DB_DATA'};
@@ -109,12 +114,28 @@ foreach (@dates_to_do)
 	print "		Extracting ids...";
 	$dt_string = sprintf("http://www.ejustice.just.fgov.be/cgi/summary_body.pl?language=%s&pub_date=%u-%02u-%02u",
 							'fr',$_->year(),$_->month(),$_->day());
-	$request = HTTP::Request->new(GET => $dt_string);
+    my $url = "https://www.ejustice.just.fgov.be/cgi/summary.pl";
+	my $data= {
+        sum_date => sprintf("%u-%02u-%02u", $_->year(),$_->month(),$_->day()),
+        language => 'fr',
+        view_numac => '',
+    };
+
+    #my $encoded_data = join('&', map { uri_escape($_) . '=' . uri_escape($data{$_}) } keys %$data);
+    my $encoded_data = join('&', map { uri_escape($_) . '=' . uri_escape($data->{$_}) } keys %$data);
+
+    my $headers = HTTP::Headers->new(
+        'Content-Type' => 'application/x-www-form-urlencoded',
+        'Accept' => 'text/html',
+    );
+    #$request = HTTP::Request->new(GET => $dt_string);
+    $request = HTTP::Request->new('POST', $url, $headers, $encoded_data);
 	$response = $browser->request($request);
 	if ($response->is_error()) {printf ("	Erreur connexion:%s\n", $response->status_line); next;}
 	$contents = $response->content();
 	my @ids=();
-	while ($contents=~ m/name=(\d{10})/gi)
+    #while ($contents=~ m/name=(\d{10})/gi)
+	while ($contents=~ m/numac_search=(\d{10})/gi)
 		{
 		push(@ids,$1);
 		}
@@ -122,7 +143,7 @@ foreach (@dates_to_do)
 	print " $count ids\n";
 		
 	########### Recording ID
-	print "		Recording ids...";
+	print "		Recording ids... (first: $ids[0])";
 	foreach $id (@ids)
 		{
 		$request = sprintf("Insert into raw_ids (doc_id, date, version) values (%u, '%s', %u)",
@@ -163,12 +184,12 @@ sub get_last_date
 {
 	my $browser = LWP::UserAgent->new();
 	$browser->timeout(30);
-	my $url = 'http://www.ejustice.just.fgov.be/cgi/summary_body.pl?language=fr&pub_date=';
+    my $url='https://www.ejustice.just.fgov.be/cgi/summary.pl?language=nl&view_numac=';
 	my $request = HTTP::Request->new(GET => $url);
 	my $response = $browser->request($request);
 	if ($response->is_error()) {printf ("	Erreur connexion:%s\n", $response->status_line); return FALSE;}
 	my $content = $response->content();
-	$content =~ /(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})<\/a>/;
+	$content =~ /sum_date=(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})&/;
 
 	return DateTime->new(year => $+{year}, month => $+{month}, day => $+{day});
 }

--- a/agent/moniteur_import/recupId.pl
+++ b/agent/moniteur_import/recupId.pl
@@ -30,7 +30,7 @@ $dates_to_parse=400;
 $max_pause = 500;
 $min_pause = 100;
 
-$version = 2;
+$version = 1;
 
 ## Database init
 $db = $ENV{'DB_DATA'};

--- a/resources/db.sql
+++ b/resources/db.sql
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS `docs` (
   KEY `prom_date` (`prom_date`),
   KEY `type` (`type`),
   KEY `version` (`version`),
-  KEY `anonymise` (`anonymise`),
+  KEY `anonymise` (`anonymise`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8 AUTO_INCREMENT=0 ;
 
 -- --------------------------------------------------------
@@ -127,7 +127,6 @@ CREATE TABLE IF NOT EXISTS `raw_pages` (
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8mb4 AUTO_INCREMENT=0 ;
 CREATE INDEX version ON raw_pages(version);                                                                             
 ALTER TABLE raw_pages ADD FULLTEXT(raw_fr);                                                                           
-~                                                   
 
 -- --------------------------------------------------------
 

--- a/resources/updates.sql
+++ b/resources/updates.sql
@@ -26,3 +26,7 @@ UPDATE types SET `ord` = 4 WHERE type_nl = 'programmawet';
 UPDATE types SET `ord` = 3 WHERE type_nl = 'wet'; 
 UPDATE types SET `ord` = 2 WHERE type_nl = 'wijziging aan de grondwet'; 
 UPDATE types SET `ord` = 100 WHERE ord IS NULL; 
+
+-- 30/05/24 : add value raw_source_version
+ALTER TABLE raw_pages ADD `raw_source_version` varchar(255);
+UPDATE raw_pages SET `raw_source_version` = 'original';


### PR DESCRIPTION
First adaptation to parse the "new" layout of the Belgian official journal.
Some observations : 
- Fundamentally, this is only a reskin : underneath it is still perl scrips serving the same content, but embedded in a new HTML structure. This means that the location of some data changed.
- Some aspects changed for no clear reason (some URLs dont work anymore) while others remained exactly the same.
- It is not yet clear if the representation of the original content is maintained (ie: the whitespaces, newlines, pragraphs, ...) This still has to be studies.

At the very least, this first fix is capable of : 
- Obtaining the latest edition's information
- Obtain the HTML of these documents
- Parse the structure for some basic metadata